### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Linguist overrides
+*.md linguist-detectable=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.sh text eol=lf
+
 # Linguist overrides
 *.md linguist-detectable=true


### PR DESCRIPTION
Adds a .gitattributes so that all `.sh` scripts are treated with LF line endings and Markdown files are counted for statistics